### PR TITLE
Fixed 'find-adr'

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ by VaultTec Corporation</span>
 
 ## <span style="color:green">Wault13Ware Team:
 - <span style="color:green">Andriy
-- <span style="color:green">Bogdan
+- <span style="color:green">Bohdan
 - <span style="color:green">Danylo
 - <span style="color:green">Vladyslav
 - <span style="color:green">Vitalii

--- a/func.py
+++ b/func.py
@@ -507,17 +507,30 @@ def del_adr(args: tuple, book: AddressBook):
 @input_error
 def find_adr(args: tuple, book: AddressBook):
     """
-    функція пошуку адреси.
+    Функція пошуку адреси.
+    Виводить на екран контакти, адреса яких містить в собі заданий підрядок
     """
     if len(args) < 1:
         raise MinArgsQuantityError
 
-    name = args[0]
-    found = book.find_address(name)
-    if found:
-        print(f"Address for {name}: {found}.")
-    else:
-        print("Address not found.")
+    substring = args[0]
+    print(f"\nContacts with '{substring}' in address:\n")
+    flag = 0
+
+    for name, record in book.items():
+        
+        # Якщо адреса не задана, то пропускаємо даний контакт
+        if record.address is None:
+            continue
+        
+        # Перевіряємо, чи адреса даного контакта містить в собі підрядок substring
+        if substring in record.address.value:
+            flag = 1
+            print(f"{name}: {record.address}")
+
+    if flag == 0:
+        print("Not found.\n")
+    else: print()               # just for design
 
 
 


### PR DESCRIPTION
'find-adr' now prints out contacts, whose address contains a given substring