### PR TITLE
Improved notes

### DIFF
--- a/classes.py
+++ b/classes.py
@@ -547,6 +547,7 @@ class Note(Field):
         self.title = ""
         self.body = ""
         self.tags = []
+        self.id = None
         self.__extract_title_and_body()
         self.__extract_tags()
 

--- a/classes.py
+++ b/classes.py
@@ -300,13 +300,6 @@ class Record:
         self.address = Address(new_address[:MAX_ADDRESS_LENGTH])
 
     def __str__(self):
-        # return_str = ''
-        # return_str += f"Contact name: {self.name.value}, \n"
-        # return_str += f"    birthday: {self.birthday}, \n"
-        # return_str += f"      phones: {'; '.join(p.value for p in self.phones)}, \n"
-        # return_str += f"      emails: {'; '.join(e.value for e in self.emails)}, \n"
-        # return_str += f"     address: {self.address}\n"
-        # return return_str
         return (f"Contact name: {self.name.value}, \n"
                 f"    birthday: {self.birthday}, \n"
                 f"      phones: {'; '.join(p.value for p in self.phones)}, \n"
@@ -578,7 +571,7 @@ class Note(Field):
     def __str__(self):
         result = ""
         if self.title:
-            result += f'Title: <<{self.title}>>\n'
+            result += f'Title: {self.title}\n'              # deleted << >> in title printing
         result += f'Body: {self.body}'
         if len(self.tags) > 0:
             result += f'\nTags: {", ".join(self.tags)}'
@@ -587,10 +580,10 @@ class Note(Field):
     def short_str(self):
         if self.title:
             return self.title
-        elif len(self.body) < 10:
+        elif len(self.body) < 30:
             return self.body
         else:
-            return f"{self.body[:10]}..."
+            return f"{self.body[:30]}..."
 
 
 class NoteBook(UserDict):

--- a/func.py
+++ b/func.py
@@ -616,22 +616,23 @@ def show_note(args, notes: NoteBook):
     Функція виведення нотатки за її номером, або всіх одразу (якщо індекс не заданий)
     '''
     if len(args) == 0:
-        for note in notes:
-            print(note)
+        for index, note in notes.items():
+            print(f"{index}: {note.short_str()}")                 # change to display
         # raise NoIdEnteredError()
         pass
-    id_to_find = int(args[0])
-    note = notes.find_note_by_id(id_to_find)
-    if note:                                        # в ідеалі треба створити метод, який би повертав рядок для виводу на display (аналог __str__ для print)
-        result = ""
-        if note.title:
-            result += f"Title: <<{note.title}>>\n"
-        result += f"Body: {note.body}"
-        if len(note.tags) > 0:
-            result += f'\nTags: {", ".join(note.tags)}'
-        display(result)
     else:
-        raise NoIdFoundError()
+        id_to_find = int(args[0])
+        note = notes.find_note_by_id(id_to_find)
+        if note:                                        # в ідеалі треба створити метод, який би повертав рядок для виводу на display (аналог __str__ для print)
+            result = ""
+            if note.title:
+                result += f"Title: <<{note.title}>>\n"
+            result += f"Body: {note.body}"
+            if len(note.tags) > 0:
+                result += f'\nTags: {", ".join(note.tags)}'
+            display(result)
+        else:
+            raise NoIdFoundError()
 
 
 @input_error

--- a/func.py
+++ b/func.py
@@ -622,8 +622,6 @@ def show_note(args, notes: NoteBook):
     Функція виведення нотатки за її номером, або всіх одразу (якщо індекс не заданий)
     '''
     
-    print(f"Current NoteBook.id: {NoteBook.id}")
-
     if len(args) == 0:
         for index, note in notes.items():
             display(f"{index}: {note.short_str()}")

--- a/func.py
+++ b/func.py
@@ -588,8 +588,14 @@ def del_note(args, notes: NoteBook):
     if len(args) == 0:
         raise NoIdEnteredError()
     id_to_delete = int(args[0])
-    if notes.delete(id_to_delete):
+    
+    if id_to_delete in range(len(notes)):
+        for index in range(id_to_delete, len(notes) - 1):
+            notes[index] = notes[index+1]
+        notes.pop(len(notes)-1)
+        NoteBook.id -= 1
         display("Note deleted")
+        print(f"Left {len(notes)} notes")
     else:
         raise NoIdFoundError()
 
@@ -615,10 +621,12 @@ def show_note(args, notes: NoteBook):
     '''
     Функція виведення нотатки за її номером, або всіх одразу (якщо індекс не заданий)
     '''
+    
+    print(f"Current NoteBook.id: {NoteBook.id}")
+
     if len(args) == 0:
         for index, note in notes.items():
-            print(f"{index}: {note.short_str()}")                 # change to display
-        # raise NoIdEnteredError()
+            display(f"{index}: {note.short_str()}")
         pass
     else:
         id_to_find = int(args[0])
@@ -626,7 +634,7 @@ def show_note(args, notes: NoteBook):
         if note:                                        # в ідеалі треба створити метод, який би повертав рядок для виводу на display (аналог __str__ для print)
             result = ""
             if note.title:
-                result += f"Title: <<{note.title}>>\n"
+                result += f"Title: {note.title}\n"
             result += f"Body: {note.body}"
             if len(note.tags) > 0:
                 result += f'\nTags: {", ".join(note.tags)}'

--- a/func.py
+++ b/func.py
@@ -340,7 +340,7 @@ def cng_email(args: tuple, book: AddressBook):
     Функція зміни пошти.
     """
     com_min_args_qty = 3    # name + old email + new email
-    if len(args) < 3:
+    if len(args) < com_min_args_qty:
         raise MinArgsQuantityError
     
     name, old_email, new_email = args
@@ -613,13 +613,16 @@ def find_note(args, notes: NoteBook):
 @input_error
 def show_note(args, notes: NoteBook):
     '''
-    Функція виведення нотатки за її номером
+    Функція виведення нотатки за її номером, або всіх одразу (якщо індекс не заданий)
     '''
     if len(args) == 0:
-        raise NoIdEnteredError()
+        for note in notes:
+            print(note)
+        # raise NoIdEnteredError()
+        pass
     id_to_find = int(args[0])
     note = notes.find_note_by_id(id_to_find)
-    if note: # в ідеалі треба створити метод, який би повертав рядок для виводу на display (аналог __str__ для print)
+    if note:                                        # в ідеалі треба створити метод, який би повертав рядок для виводу на display (аналог __str__ для print)
         result = ""
         if note.title:
             result += f"Title: <<{note.title}>>\n"


### PR DESCRIPTION
- `show-note` without arguments prints out all notes
- deleting notes shifts all left indices to fill in the empty one

Attention: to better functionality delete your previous **.note_book.json** file and start doing notes again